### PR TITLE
Add decision pathway analysis and display

### DIFF
--- a/decision_tree_app.py
+++ b/decision_tree_app.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+"""Utility classes for working with decision trees.
+
+The :class:`DecisionTree` class converts the in-memory ``graph`` used by
+``streamlit_app.py`` into a structure that can be traversed to produce all
+possible decision pathways.  Each pathway lists the ordered steps from the
+root node to an end node together with its cumulative probability.
+
+This module is intentionally lightweight and free of any Streamlit
+dependencies so that it can be tested and reused independently from the UI.
+"""
+
+from dataclasses import dataclass
+from collections import defaultdict
+from typing import Dict, List, Optional
+
+
+@dataclass
+class Node:
+    """A single node in the decision tree."""
+
+    id: str
+    label: str
+    kind: str  # ``event``, ``decision`` or ``result``
+
+
+@dataclass
+class Edge:
+    """A connection between two nodes."""
+
+    source: str
+    target: str
+    label: Optional[str] = None
+    prob: Optional[float] = None
+
+
+@dataclass
+class Pathway:
+    """A fully qualified path from a root to a leaf node."""
+
+    steps: List[str]
+    probability: float
+
+
+class DecisionTree:
+    """A representation of the decision tree and traversal helpers."""
+
+    def __init__(self, nodes: List[Node], edges: List[Edge]):
+        self.nodes: Dict[str, Node] = {n.id: n for n in nodes}
+        self.edges = edges
+        self._outgoing: Dict[str, List[Edge]] = defaultdict(list)
+        self._incoming: Dict[str, List[Edge]] = defaultdict(list)
+        for e in edges:
+            self._outgoing[e.source].append(e)
+            self._incoming[e.target].append(e)
+
+    @classmethod
+    def from_graph(cls, graph: dict) -> "DecisionTree":
+        """Create a :class:`DecisionTree` from a Streamlit ``graph`` dict."""
+
+        nodes = [
+            Node(id=n["id"], label=n["data"]["label"], kind=n.get("kind", "event"))
+            for n in graph.get("nodes", [])
+        ]
+        edges = []
+        for e in graph.get("edges", []):
+            data = e.get("data", {})
+            edges.append(
+                Edge(
+                    source=e["source"],
+                    target=e["target"],
+                    label=e.get("label"),
+                    prob=data.get("prob"),
+                )
+            )
+        return cls(nodes, edges)
+
+    # ------------------------------------------------------------------
+    # Traversal helpers
+    # ------------------------------------------------------------------
+    def _roots(self) -> List[Node]:
+        return [n for n in self.nodes.values() if not self._incoming.get(n.id)]
+
+    def pathways(self) -> List[Pathway]:
+        """Return all root-to-leaf paths with cumulative probabilities."""
+
+        results: List[Pathway] = []
+
+        def dfs(node_id: str, path: List[str], prob: float) -> None:
+            node = self.nodes[node_id]
+            path.append(node.label)
+            children = self._outgoing.get(node_id)
+            if not children:
+                results.append(Pathway(steps=path.copy(), probability=prob))
+            else:
+                for edge in children:
+                    edge_steps = path + ([f"[{edge.label}]"] if edge.label else [])
+                    edge_prob = edge.prob if edge.prob is not None else 1.0
+                    dfs(edge.target, edge_steps, prob * edge_prob)
+            path.pop()
+
+        for root in self._roots():
+            dfs(root.id, [], 1.0)
+        return results
+
+
+__all__ = ["Node", "Edge", "Pathway", "DecisionTree"]

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,10 +1,12 @@
 import json
 import uuid
-import urllib.parse
 from collections import defaultdict
 
+import pandas as pd
 import streamlit as st
 import streamlit.components.v1 as components
+
+from decision_tree_app import DecisionTree
 
 st.set_page_config(page_title="Decision Tree – Auto-Compute & Export", layout="wide")
 st.title("🌳 Decision Tree – Left → Right with Auto-Compute & PNG Export")
@@ -168,6 +170,21 @@ if warnings:
     st.markdown("#### ⚠️ Warnings")
     for w in warnings:
         st.warning(w)
+
+# ---------------------------
+# Decision Pathways
+# ---------------------------
+tree = DecisionTree.from_graph(graph)
+paths = tree.pathways()
+if paths:
+    st.markdown("#### 🗺 Decision Pathways")
+    df = pd.DataFrame(
+        {
+            "Path": [" → ".join(p.steps) for p in paths],
+            "Probability": [round(p.probability, 3) for p in paths],
+        }
+    )
+    st.table(df)
 
 # ---------------------------
 # Canvas Visualization


### PR DESCRIPTION
## Summary
- add reusable decision tree module to compute all root-to-leaf pathways with cumulative probabilities
- enhance Streamlit UI to display decision pathways using the new module

## Testing
- `python -m py_compile decision_tree_app.py streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_6894ca54a818833095910811daea30ef