### PR TITLE
Improve decision tree app UX and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,47 @@
-# 🎈 Blank app template
+# 🌳 Decision Tree Builder
 
-A simple Streamlit app template for you to modify!
+An interactive Streamlit app for creating and analysing decision trees from left to right.
 
-[![Open in Streamlit](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://blank-app-template.streamlit.app/)
+## Features
 
-### How to run it on your own machine
+- Visual canvas for building decision trees
+- Add, edit and delete nodes (event, decision and result)
+- Connect nodes with labelled edges and optional probabilities; edit or remove edges
+- Automatically distribute probabilities across outgoing edges of decision nodes
+- Export or import the tree structure as JSON
+- Display decision pathways with their cumulative probabilities
+- Export the canvas as a PNG image
+
+## Setup
 
 1. Install the requirements
 
-   ```
-   $ pip install -r requirements.txt
+   ```bash
+   pip install -r requirements.txt
    ```
 
 2. Run the app
 
+   ```bash
+   streamlit run streamlit_app.py
    ```
-   $ streamlit run streamlit_app.py
-   ```
+
+## Using the App
+
+1. **Add nodes** in the sidebar by providing a label and node type.
+2. **Edit or delete nodes** via the *Edit Node* sidebar section. Deleting a node also removes its connected edges.
+3. **Add edges** between nodes with optional labels and probabilities.
+4. **Edit or delete edges** in the *Edit Edge* sidebar section.
+5. Use the **Actions** toolbar to export the current tree to JSON, import a saved tree, clear the canvas or auto-compute probabilities for decision nodes.
+6. The **Decision Pathways** table lists each path from root to leaf with its cumulative probability.
+7. Click **Export PNG** on the canvas to download an image of the current tree.
+
+## Examples and Tutorials
+
+An example JSON file is provided at [`examples/basic_tree.json`](examples/basic_tree.json).
+Additional tutorials and sample trees will be added to the repository.
+
+## License
+
+[MIT](LICENSE)
+

--- a/examples/basic_tree.json
+++ b/examples/basic_tree.json
@@ -1,0 +1,13 @@
+{
+  "nodes": [
+    {"id": "n_start", "data": {"label": "Start"}, "kind": "event"},
+    {"id": "n_decide", "data": {"label": "Decision"}, "kind": "decision"},
+    {"id": "n_yes", "data": {"label": "Yes Outcome"}, "kind": "result"},
+    {"id": "n_no", "data": {"label": "No Outcome"}, "kind": "result"}
+  ],
+  "edges": [
+    {"id": "e_start_decide", "source": "n_start", "target": "n_decide", "label": null, "data": {}},
+    {"id": "e_decide_yes", "source": "n_decide", "target": "n_yes", "label": "Yes", "data": {"prob": 0.5}},
+    {"id": "e_decide_no", "source": "n_decide", "target": "n_no", "label": "No", "data": {"prob": 0.5}}
+  ]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,2 @@
 streamlit>=1.33.0
 pandas>=2.0.0
-networkx>=3.0
-matplotlib>=3.7.0
-openpyxl>=3.1.2
-pyvis>=0.3.2

--- a/st_react_flow/__init__.py
+++ b/st_react_flow/__init__.py
@@ -1,36 +1,44 @@
+import logging
 import os
 import streamlit as st
 import streamlit.components.v1 as components
 
-# Path to this component folder
+logger = logging.getLogger(__name__)
+
 _component_dir = os.path.dirname(os.path.abspath(__file__))
 _build_dir = os.path.join(_component_dir, "build")
 
-# Diagnostics: print path info
-st.write(f"🔍 React Flow Component Path: {_build_dir}")
 if not os.path.exists(_build_dir):
-    st.error(f"❌ React Flow build directory not found: {_build_dir}")
-    st.warning("Please ensure you ran `npm run build` in st_react_flow/frontend and committed the build folder.")
-else:
-    st.success("✅ React Flow build directory found.")
+    raise FileNotFoundError(f"React Flow build directory not found: {_build_dir}")
 
-# Declare the production component
 _react_flow_prod = components.declare_component(
     "react_flow_canvas_prod",
-    path=_build_dir
+    path=_build_dir,
 )
 
-def react_flow(key: str, value=None, dev: bool = False):
+def react_flow(key: str, value=None, dev: bool = False, debug: bool = False):
+    """Render the React Flow decision tree component.
+
+    Parameters
+    ----------
+    key:
+        Unique Streamlit key for the component instance.
+    value:
+        Initial graph dictionary passed to the component.
+    dev:
+        When ``True`` connects to the Vite dev server on ``localhost:5173``.
+    debug:
+        When ``True`` prints diagnostic information to the Streamlit app.
     """
-    Streamlit wrapper for the React Flow decision tree component.
-    If dev=True, connects to the Vite dev server (localhost:5173).
-    Otherwise, uses the compiled assets in st_react_flow/build.
-    """
+    if debug:
+        st.write(f"React Flow component path: {_build_dir}")
+
     if dev:
         _react_flow_dev = components.declare_component(
             "react_flow_canvas_dev",
-            url="http://localhost:5173"
+            url="http://localhost:5173",
         )
         return _react_flow_dev(key=key, value=value, default=value or {})
     else:
         return _react_flow_prod(key=key, value=value, default=value or {})
+


### PR DESCRIPTION
## Summary
- document decision tree app with setup instructions and example JSON
- allow editing and removal of nodes and edges in the Streamlit sidebar
- silence React Flow import diagnostics and prune unused dependencies
- drop binary screenshot and update README accordingly

## Testing
- `python -m py_compile decision_tree_app.py streamlit_app.py st_react_flow/__init__.py`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_6894d0859a1483308d6e81ccac0bbb38