### PR TITLE
Expand canvas size for decision tree viewer

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -291,7 +291,9 @@ vis_html = f"""
   <style>
     html, body {{ height: 100%; margin: 0; background: #f8fafc; }}
     #network {{
-      height: 620px;
+      width: 100%;
+      height: 100%;
+      min-height: 620px;
       background: #f1f5f9;
       border-radius: 8px;
       border: 1px solid #cbd5e1;
@@ -356,4 +358,5 @@ vis_html = f"""
 </html>
 """
 st.markdown("### Canvas")
-components.html(vis_html, height=650, scrolling=False)
+# Allow the canvas to expand to fill available space without overlapping
+components.html(vis_html, height=800, scrolling=False)


### PR DESCRIPTION
## Summary
- allow canvas to grow with available space by using full width/height styling
- increase embedded component height so the visualization occupies a larger area

## Testing
- `python -m py_compile streamlit_app.py decision_tree_app.py`

------
https://chatgpt.com/codex/tasks/task_e_6894d78fadb88330baab75397909a1a7