### PR TITLE
Redesign node taxonomy with utility and cost/benefit metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ An interactive Streamlit app for creating and analysing decision trees from left
 ## Features
 
 - Visual canvas for building decision trees
-- Add, edit and delete nodes (event, decision and result)
+- Add, edit and delete nodes (decision, chance, outcome and utility)
 - Connect nodes with labelled edges and optional probabilities; edit or remove edges
-- Automatically distribute probabilities across outgoing edges of decision nodes
+- Automatically distribute probabilities across outgoing edges of chance nodes
 - Export or import the tree structure as JSON
-- Display decision pathways with their cumulative probabilities
+- Display decision pathways with their cumulative probabilities, costs, benefits and payoffs
 - Export the canvas as a PNG image
 
 ## Setup
@@ -32,8 +32,8 @@ An interactive Streamlit app for creating and analysing decision trees from left
 2. **Edit or delete nodes** via the *Edit Node* sidebar section. Deleting a node also removes its connected edges.
 3. **Add edges** between nodes with optional labels and probabilities.
 4. **Edit or delete edges** in the *Edit Edge* sidebar section.
-5. Use the **Actions** toolbar to export the current tree to JSON, import a saved tree, clear the canvas or auto-compute probabilities for decision nodes.
-6. The **Decision Pathways** table lists each path from root to leaf with its cumulative probability.
+5. Use the **Actions** toolbar to export the current tree to JSON, import a saved tree, clear the canvas or auto-compute probabilities for chance nodes.
+6. The **Decision Pathways** table lists each path from root to leaf with its cumulative probability, cost, benefit and payoff.
 7. Click **Export PNG** on the canvas to download an image of the current tree.
 
 ## Examples and Tutorials

--- a/examples/basic_tree.json
+++ b/examples/basic_tree.json
@@ -1,9 +1,9 @@
 {
   "nodes": [
-    {"id": "n_start", "data": {"label": "Start"}, "kind": "event"},
+    {"id": "n_start", "data": {"label": "Start"}, "kind": "chance"},
     {"id": "n_decide", "data": {"label": "Decision"}, "kind": "decision"},
-    {"id": "n_yes", "data": {"label": "Yes Outcome"}, "kind": "result"},
-    {"id": "n_no", "data": {"label": "No Outcome"}, "kind": "result"}
+    {"id": "n_yes", "data": {"label": "Yes Outcome"}, "kind": "outcome"},
+    {"id": "n_no", "data": {"label": "No Outcome"}, "kind": "outcome"}
   ],
   "edges": [
     {"id": "e_start_decide", "source": "n_start", "target": "n_decide", "label": null, "data": {}},

--- a/st_react_flow/frontend/src/App.tsx
+++ b/st_react_flow/frontend/src/App.tsx
@@ -13,11 +13,45 @@ import "reactflow/dist/style.css";
 import { nanoid } from "nanoid";
 import { Streamlit, StreamlitComponentBase, withStreamlitConnection } from "streamlit-component-lib";
 import type { NodeData, EdgeData, NodeKind } from "./types";
+import type { CSSProperties } from "react";
 
 type Graph = { nodes: Node<NodeData>[]; edges: Edge<EdgeData>[] };
 
 function color(kind: NodeKind) {
-  return kind === "event" ? "#1d4ed8" : kind === "decision" ? "#16a34a" : "#f97316";
+  switch (kind) {
+    case "chance":
+      return "#1d4ed8";
+    case "decision":
+      return "#16a34a";
+    case "outcome":
+      return "#f97316";
+    case "utility":
+      return "#eab308";
+    default:
+      return "#777";
+  }
+}
+
+function shapeStyle(kind: NodeKind): CSSProperties {
+  const base: CSSProperties = {
+    border: `2px solid ${color(kind)}`,
+    background: "#fff",
+    width: 150,
+    height: 150,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+  };
+  switch (kind) {
+    case "chance":
+      return { ...base, borderRadius: "50%" };
+    case "outcome":
+      return { ...base, clipPath: "polygon(50% 0, 0 100%, 100% 100%)" };
+    case "utility":
+      return { ...base, clipPath: "polygon(50% 0, 100% 50%, 50% 100%, 0 50%)" };
+    default:
+      return base;
+  }
 }
 
 class App extends StreamlitComponentBase<any> {
@@ -41,7 +75,7 @@ class App extends StreamlitComponentBase<any> {
       type: "default",
       position: { x: 200, y: 100 },
       data: { label: `${kind} node`, kind },
-      style: { border: `2px solid ${color(kind)}`, background: "#fff", minWidth: 150 }
+      style: shapeStyle(kind),
     };
     this.setState((s: any) => ({ nodes: [...s.nodes, node] }));
   };
@@ -61,9 +95,10 @@ class App extends StreamlitComponentBase<any> {
     return (
       <div style={{ width: "100vw", height: "80vh" }}>
         <div className="toolbar">
-          <button onClick={() => this.addNode("event")}>+ Event</button>
           <button onClick={() => this.addNode("decision")}>+ Decision</button>
-          <button onClick={() => this.addNode("result")}>+ Result</button>
+          <button onClick={() => this.addNode("chance")}>+ Chance</button>
+          <button onClick={() => this.addNode("outcome")}>+ Outcome</button>
+          <button onClick={() => this.addNode("utility")}>+ Utility</button>
           <a
             href={`data:application/json,${encodeURIComponent(JSON.stringify({ nodes, edges }, null, 2))}`}
             download="decision_tree.json"

--- a/st_react_flow/frontend/src/types.ts
+++ b/st_react_flow/frontend/src/types.ts
@@ -1,8 +1,11 @@
-export type NodeKind = "event" | "decision" | "result";
+export type NodeKind = "decision" | "chance" | "outcome" | "utility";
 
 export interface NodeData {
   label: string;
   kind: NodeKind;
+  value?: number;
+  cost?: number;
+  benefit?: number;
 }
 
 export interface EdgeData {


### PR DESCRIPTION
## Summary
- adopt standard decision, chance, outcome and utility node types throughout the app
- capture optional cost, benefit and payoff metadata and propagate it through pathway calculations
- map each node type to conventional colors and shapes in the Streamlit canvas and React Flow component

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module vite/dist/node/cli.js)*

------
https://chatgpt.com/codex/tasks/task_e_6894db2ac91483309cf9eddeebdd9644