### PR TITLE
Load example tree by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ An interactive Streamlit app for creating and analysing decision trees from left
 
 ## Examples and Tutorials
 
-An example JSON file is provided at [`examples/basic_tree.json`](examples/basic_tree.json).
+An example JSON file is provided at [`examples/basic_tree.json`](examples/basic_tree.json) and is loaded by default when the app starts so you can see the expected format.
 Additional tutorials and sample trees will be added to the repository.
 
 ## License

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,6 +1,7 @@
 import json
 import uuid
 from collections import defaultdict
+from pathlib import Path
 
 import pandas as pd
 import streamlit as st
@@ -59,7 +60,9 @@ def auto_compute_probabilities(graph: dict):
 # Session state
 # ---------------------------
 if "graph" not in st.session_state:
-    st.session_state.graph = {"nodes": [], "edges": []}
+    example_path = Path(__file__).parent / "examples" / "basic_tree.json"
+    with example_path.open() as f:
+        st.session_state.graph = json.load(f)
 
 graph = st.session_state.graph
 


### PR DESCRIPTION
## Summary
- Preload a sample decision tree from `examples/basic_tree.json` when the app starts
- Clarify in README that the example tree loads automatically to show the expected JSON format

## Testing
- `python -m py_compile streamlit_app.py decision_tree_app.py`


------
https://chatgpt.com/codex/tasks/task_e_6894e561c2e483308f73c63a2041f8fa