### PR TITLE
refactor: manage react flow viewport

### DIFF
--- a/st_react_flow/frontend/src/App.tsx
+++ b/st_react_flow/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import ReactFlow, {
   Background,
   Controls,
@@ -7,74 +7,98 @@ import ReactFlow, {
   Edge,
   NodeChange,
   EdgeChange,
+  Viewport,
   applyNodeChanges,
   applyEdgeChanges,
+  ReactFlowProvider,
+  useReactFlow,
 } from "reactflow";
 import "reactflow/dist/style.css";
-import { Streamlit, StreamlitComponentBase, withStreamlitConnection } from "streamlit-component-lib";
+import { Streamlit, withStreamlitConnection } from "streamlit-component-lib";
 import type { NodeData, EdgeData } from "./types";
 
-class App extends StreamlitComponentBase<any> {
-  state = {
-    nodes: (this.props.args?.value?.nodes ?? []) as Node<NodeData>[],
-    edges: (this.props.args?.value?.edges ?? []) as Edge<EdgeData>[],
-  };
+const Flow = (props: any) => {
+  const [nodes, setNodes] = useState<Node<NodeData>[]>(
+    (props.args?.value?.nodes ?? []) as Node<NodeData>[]
+  );
+  const [edges, setEdges] = useState<Edge<EdgeData>[]>(
+    (props.args?.value?.edges ?? []) as Edge<EdgeData>[]
+  );
+  const [viewport, setViewport] = useState<Viewport | null>(null);
+  const reactFlowInstance = useReactFlow();
+  const hasFitView = useRef(false);
+  const isInitialRender = useRef(true);
 
-  componentDidMount() {
+  useEffect(() => {
     Streamlit.setFrameHeight();
-  }
+  });
 
-  componentDidUpdate(prevProps: any, prevState: any) {
-    Streamlit.setFrameHeight();
-    const prevValue = prevProps.args?.value;
-    const currValue = this.props.args?.value;
-    if (prevValue !== currValue) {
-      this.setState({
-        nodes: (currValue?.nodes ?? []) as Node<NodeData>[],
-        edges: (currValue?.edges ?? []) as Edge<EdgeData>[],
-      });
+  useEffect(() => {
+    const value = props.args?.value;
+    setNodes((value?.nodes ?? []) as Node<NodeData>[]);
+    setEdges((value?.edges ?? []) as Edge<EdgeData>[]);
+  }, [props.args?.value]);
+
+  useEffect(() => {
+    if (isInitialRender.current) {
+      isInitialRender.current = false;
+      return;
     }
-    if (
-      prevState.nodes !== this.state.nodes ||
-      prevState.edges !== this.state.edges
-    ) {
-      Streamlit.setComponentValue({ nodes: this.state.nodes, edges: this.state.edges });
+    Streamlit.setComponentValue({ nodes, edges });
+  }, [nodes, edges]);
+
+  useEffect(() => {
+    if (nodes.length > 0) {
+      if (!hasFitView.current && !viewport) {
+        reactFlowInstance.fitView();
+        setViewport(reactFlowInstance.getViewport());
+        hasFitView.current = true;
+      } else if (viewport) {
+        reactFlowInstance.setViewport(viewport);
+      }
     }
-  }
+  }, [nodes, reactFlowInstance, viewport]);
 
-  onNodesChange = (changes: NodeChange[]) => {
+  const onNodesChange = useCallback((changes: NodeChange[]) => {
     const filtered = changes.filter((c) => c.type !== "remove");
-    this.setState((s: any) => ({ nodes: applyNodeChanges(filtered, s.nodes) }));
-  };
+    setNodes((nds) => applyNodeChanges(filtered, nds));
+  }, []);
 
-  onEdgesChange = (changes: EdgeChange[]) => {
+  const onEdgesChange = useCallback((changes: EdgeChange[]) => {
     const filtered = changes.filter((c) => c.type !== "remove");
-    this.setState((s: any) => ({ edges: applyEdgeChanges(filtered, s.edges) }));
-  };
+    setEdges((eds) => applyEdgeChanges(filtered, eds));
+  }, []);
 
-  render() {
-    const { nodes, edges } = this.state;
-    const styledEdges = edges.map((e) =>
-      (e as any).color ? { ...e, style: { stroke: (e as any).color } } : e
-    );
+  const onMove = useCallback((_, vp: Viewport) => {
+    setViewport(vp);
+  }, []);
 
-    return (
-      <div style={{ width: "100vw", height: "80vh" }}>
-        <ReactFlow
-          nodes={nodes}
-          edges={styledEdges}
-          onNodesChange={this.onNodesChange}
-          onEdgesChange={this.onEdgesChange}
-          fitView
-        >
-          <MiniMap />
-          <Controls />
-          <Background variant="dots" gap={12} size={1} />
-        </ReactFlow>
-      </div>
-    );
-  }
-}
+  const styledEdges = edges.map((e) =>
+    (e as any).color ? { ...e, style: { stroke: (e as any).color } } : e
+  );
+
+  return (
+    <div style={{ width: "100vw", height: "80vh" }}>
+      <ReactFlow
+        nodes={nodes}
+        edges={styledEdges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onMove={onMove}
+      >
+        <MiniMap />
+        <Controls />
+        <Background variant="dots" gap={12} size={1} />
+      </ReactFlow>
+    </div>
+  );
+};
+
+const App = (props: any) => (
+  <ReactFlowProvider>
+    <Flow {...props} />
+  </ReactFlowProvider>
+);
 
 export default withStreamlitConnection(App);
 


### PR DESCRIPTION
## Summary
- wrap React Flow with ReactFlowProvider and move to hooks-based component
- persist and restore viewport while fitting view on initial node population

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a37bd53e808330be8d2aa035171a9d