### PR TITLE
style: improve edge styling and defaults

### DIFF
--- a/st_react_flow/frontend/src/App.tsx
+++ b/st_react_flow/frontend/src/App.tsx
@@ -106,9 +106,25 @@ const Flow = (props: any) => {
     setViewport(vp);
   }, []);
 
-  const styledEdges = edges.map((e) =>
-    (e as any).color ? { ...e, style: { stroke: (e as any).color } } : e
-  );
+  const uniqueEdges = edges.filter((e, index, arr) => {
+    const hasRequired = e.id && e.source && e.target;
+    const duplicateIndex = arr.findIndex(
+      (other) =>
+        other.id === e.id &&
+        other.source === e.source &&
+        other.target === e.target
+    );
+    return hasRequired && duplicateIndex === index;
+  });
+
+  const styledEdges = uniqueEdges.map((e) => {
+    const style: any = { strokeWidth: 2 };
+    if ((e as any).color) {
+      style.stroke = (e as any).color;
+    }
+    const markerEnd = (e as any).markerEnd;
+    return markerEnd ? { ...e, style, markerEnd } : { ...e, style };
+  });
 
   return (
     <div style={{ width: "100vw", height: "80vh" }}>
@@ -118,6 +134,7 @@ const Flow = (props: any) => {
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
         onMove={onMove}
+        defaultEdgeOptions={{ style: { strokeWidth: 2 }, type: 'straight' }}
       >
         <MiniMap />
         <Controls />


### PR DESCRIPTION
## Summary
- ensure edges have unique id, source, and target before styling
- add stroke width and optional markerEnd to edge styles
- set default edge options for ReactFlow to straight with stroke width 2

## Testing
- `cd st_react_flow/frontend && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a39c1c53388330a98d47d28b04684c