### PR TITLE
feat: add agraph rendering option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ An interactive Streamlit app for freely creating and organising ideas as a mind 
 
 ## Features
 
-- Visual canvas powered by [`streamlit-drawable-canvas`](https://github.com/andfanilo/streamlit-drawable-canvas)
+- Visual canvas powered by React Flow with an optional [`streamlit-agraph`](https://github.com/ChrisDelClea/streamlit-agraph) renderer
 - Add, edit or delete nodes and edges from the sidebar
-- Drag nodes on the canvas to arrange them without losing their position
+- Drag nodes on the React Flow canvas to arrange them without losing their position
 - Edges can be color-coded and are drawn with thicker lines for visibility
 - Export or import the map structure as JSON
 
@@ -30,8 +30,12 @@ An interactive Streamlit app for freely creating and organising ideas as a mind 
 2. **Edit or delete nodes** via the *Edit Node* sidebar section. Deleting a node also removes its connected edges.
 3. **Add edges** between nodes using the sidebar and optionally provide a label.
 4. **Edit or delete edges** in the *Edit Edge* sidebar section.
-5. **Drag nodes on the canvas** to reposition them.
+5. Choose the canvas engine in the *Canvas Settings* sidebar section. React Flow supports drag-and-drop positioning, while the Agraph option is read-only and relies on automatic layout.
 6. Use the **Actions** toolbar to export the current map to JSON, import a saved map or clear the canvas.
+
+### Limitations
+
+- The Agraph renderer is experimental and does not currently allow manual node positioning. Editing still occurs through the sidebar forms.
 
 ## Examples and Tutorials
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 streamlit>=1.33.0
 streamlit-drawable-canvas>=0.9.3
+streamlit-agraph>=0.0.45

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -3,10 +3,19 @@ import uuid
 
 import streamlit as st
 from st_react_flow import react_flow
+from streamlit_agraph import agraph, Node, Edge, Config
 
 st.set_page_config(page_title="Mind Map Builder", layout="wide")
+# Title and basic config
 st.title("🧠 Mind Map Builder")
 
+# ---------------------------
+# Canvas settings
+# ---------------------------
+st.sidebar.header("⚙️ Canvas Settings")
+canvas_renderer = st.sidebar.radio(
+    "Renderer", ["React Flow", "Agraph"], index=0, help="Choose the graph canvas implementation"
+)
 
 def new_edge_id() -> str:
     return f"e_{uuid.uuid4().hex[:6]}"
@@ -152,9 +161,26 @@ with action_col3:
  # ---------------------------
 st.markdown("### Canvas")
 
-result = react_flow(key="mindmap", value=graph)
-if result:
-    graph["nodes"] = result.get("nodes", [])
-    graph["edges"] = result.get("edges", [])
+if canvas_renderer == "React Flow":
+    result = react_flow(key="mindmap", value=graph)
+    if result:
+        graph["nodes"] = result.get("nodes", [])
+        graph["edges"] = result.get("edges", [])
+else:
+    agraph_nodes = [
+        Node(
+            id=n["id"],
+            label=n["data"]["label"],
+            x=n.get("position", {}).get("x"),
+            y=n.get("position", {}).get("y"),
+        )
+        for n in graph["nodes"]
+    ]
+    agraph_edges = [
+        Edge(source=e["source"], target=e["target"], label=e.get("label"), color=e.get("color"))
+        for e in graph["edges"]
+    ]
+    config = Config(width=750, height=500, directed=True)
+    agraph(nodes=agraph_nodes, edges=agraph_edges, config=config)
 
 


### PR DESCRIPTION
## Summary
- add `streamlit-agraph` dependency
- prototype an alternate Agraph canvas with a sidebar switch
- document usage and limitations of the new renderer

## Testing
- `python -m py_compile streamlit_app.py decision_tree_app.py`
- `pip install streamlit-agraph` *(fails: Cannot connect to proxy, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a5b055708330a68def50369c0e2a