### PR TITLE
Preserve node positions when adding nodes

### DIFF
--- a/st_react_flow/frontend/src/App.tsx
+++ b/st_react_flow/frontend/src/App.tsx
@@ -74,7 +74,10 @@ const Flow = (props: any) => {
         const incoming = (value.nodes ?? []) as Node<NodeData>[];
         return incoming.map((n) => {
           const existing = prevMap.get(n.id);
-          return existing ? { ...existing, ...n } : n;
+          if (existing) {
+            return { ...existing, ...n, position: existing.position };
+          }
+          return n;
         });
       });
 


### PR DESCRIPTION
## Summary
- Preserve existing node coordinates when merging updates from Streamlit so nodes don't reset when new nodes are added.

## Testing
- `python -m pytest`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a49538d784833096406f0f2bf8733d