### PR TITLE
Enable physics in agraph to avoid node overlap

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -202,7 +202,7 @@ else:
         Edge(source=e["source"], target=e["target"], label=e.get("label"), color=e.get("color"))
         for e in graph["edges"]
     ]
-    config = Config(width=750, height=500, directed=True, physics=False, stabilization=False)
+    config = Config(width=750, height=500, directed=True, physics=True, stabilization=True)
     agraph(nodes=agraph_nodes, edges=agraph_edges, config=config)
 
 


### PR DESCRIPTION
## Summary
- enable physics in `streamlit-agraph` config so nodes are spaced apart and recalculated on updates

## Testing
- `python -m py_compile streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a49ba1017083309fbe052a6be2b1c5