### PR TITLE
Disable automatic node movement on agraph canvas

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -202,7 +202,13 @@ else:
         Edge(source=e["source"], target=e["target"], label=e.get("label"), color=e.get("color"))
         for e in graph["edges"]
     ]
-    config = Config(width=750, height=500, directed=True, physics=True, stabilization=True)
+    config = Config(
+        width=750,
+        height=500,
+        directed=True,
+        physics=False,
+        stabilization=False,
+    )
     agraph(nodes=agraph_nodes, edges=agraph_edges, config=config)
 
 


### PR DESCRIPTION
## Summary
- disable vis-network physics so nodes remain static unless manually dragged

## Testing
- `python -m py_compile streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a49f67a9bc8330a90e6c5b1b4bc0ef