### PR TITLE
Offset new node positions

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -57,13 +57,17 @@ with st.sidebar.expander("➕ Add Node", expanded=True):
         node_shape = st.selectbox("Shape", NODE_SHAPES, index=0)
         add_node_btn = st.form_submit_button("Add node")
     if add_node_btn and node_label:
+        node_index = len(graph["nodes"])
+        offset = 50
+        position = {"x": node_index * offset, "y": node_index * offset}
         graph["nodes"].append(
             {
                 "id": new_node_id(),
                 "data": {"label": node_label, "shape": node_shape},
-                "position": {"x": 0, "y": 0},
+                "position": position,
             }
         )
+        st.session_state.graph = graph
 
 if graph["nodes"]:
     with st.sidebar.expander("✏️ Edit Node", expanded=True):


### PR DESCRIPTION
## Summary
- Offset new node positions using incremental x/y offsets based on node count
- Store node positions in session state for persistence across reruns

## Testing
- `python -m py_compile streamlit_app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4a282fb5c83308729276f4afe98cc