### PR TITLE
Fix edge creation selecting incorrect source

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -98,10 +98,15 @@ if len(graph["nodes"]) >= 2:
     node_labels = {n["id"]: n["data"]["label"] for n in graph["nodes"]}
 
     with st.sidebar.expander("➕ Add Edge", expanded=True):
-        with st.form("add_edge_form", clear_on_submit=True):
-            source = st.selectbox("Source", list(node_labels.keys()), format_func=lambda x: node_labels[x])
+        with st.form("add_edge_form"):
+            source = st.selectbox(
+                "Source", list(node_labels.keys()), format_func=lambda x: node_labels[x], key="add_edge_source"
+            )
             target = st.selectbox(
-                "Target", [n["id"] for n in graph["nodes"] if n["id"] != source], format_func=lambda x: node_labels[x]
+                "Target",
+                [n["id"] for n in graph["nodes"] if n["id"] != source],
+                format_func=lambda x: node_labels[x],
+                key="add_edge_target",
             )
             edge_label = st.text_input("Edge label (optional)")
             edge_color = st.color_picker("Color", "#000000")


### PR DESCRIPTION
## Summary
- ensure Add Edge form keeps user selections by removing `clear_on_submit`
- use keyed select boxes so edge connections use the chosen source and target

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4a82a989c8330a5d6ea3deacecce9